### PR TITLE
adds 'layout: null' to scss files to avoid build errors

### DIFF
--- a/lib/brume/public/css/main.scss
+++ b/lib/brume/public/css/main.scss
@@ -1,4 +1,5 @@
 ---
+layout: null
 ---
 
 @import 'syntax';

--- a/lib/clean-jekyll/css/main.scss
+++ b/lib/clean-jekyll/css/main.scss
@@ -1,4 +1,5 @@
 ---
+layout: null
 # Only the main Sass file needs front matter (the dashes are enough)
 ---
 @charset "utf-8";


### PR DESCRIPTION
I've been getting emails from github about this and am hoping this fixes it.  Unfortunately won't know until I merge and deploy to Heroku. 
